### PR TITLE
Fix callbacks not being called when connection is closed

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -94,6 +94,12 @@ Connection.prototype.connect = function(fn){
 
   this.sock.on('close', function(){
     self._ready = false;
+
+    if (callbacks.length || self.callbacks.length) {
+      err = new Error('socket closed without releasing callbacks');
+      error(err, callbacks);
+      error(err, self.callbacks);
+    }
   });
 
   this.sock.on('error', function(err){

--- a/test/unit/connection.js
+++ b/test/unit/connection.js
@@ -93,6 +93,24 @@ describe('Connection#connect(fn)', function(){
 })
 
 describe('Connection#command(name, args, data)', function(){
+  it('should call callbacks with error when connection is closed', function (done) {
+    var conn = new Connection;
+
+    conn.on('ready', function(){
+      conn.sock.write = function () {
+        // trigger a socket 'close' event
+        conn.sock.end();
+      };
+
+      conn.command('PUB', ['events'], new Buffer('foo bar'), function() {
+        conn.callbacks.should.eql([]);
+        done();
+      });
+    });
+
+    conn.connect();
+  })
+
   it('should write command, args and data', function(){
     var conn = new Connection;
     var writes = [];


### PR DESCRIPTION
Consider the following use case:

* A writer emits a `PUBLISH ...` and is waiting for the `OK` from the socket.
* The connection is unexpectedly closed.

Without this PR, the client will never receive the callback and will wait indefinitely. This PR will "reject" all pending callbacks when closing a connection.