### PR TITLE
Clear reconnect attempts on ready

### DIFF
--- a/lib/mixins/reconnect.js
+++ b/lib/mixins/reconnect.js
@@ -17,7 +17,7 @@ module.exports = function(conn, max){
   var backoff = new Backoff({ min: 100, max: 10000, jitter: 200 });
   var attempts = 0;
 
-  conn.on('connect', function(){
+  conn.on('ready', function(){
     debug('%s - reset backoff', conn.addr);
     backoff.reset();
     attempts = 0;


### PR DESCRIPTION
We are clearing the reconnect attempts after connecting to the socket, but it makes more sense to clear the attempts after protocol negotiation is finished and the `ready` event is emitted.
As is, if you connect to a different port that is not nsqd, the lib hangs with an infinite reconnect loop since it can establish the socket connection (clearing the reconnect attempts) but throws an error when negotiating the protocol.