### PR TITLE
Avoid adding dynamic listeners to writer

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -38,6 +38,7 @@ function Writer(opts) {
   this.opts = utils.address(opts);
   this.conns = new Set;
   this.pendingConns = new Set;
+  this.publishQueue = [];
 
   this.connect();
   this.n = 0;
@@ -84,11 +85,7 @@ Writer.prototype.publish = function(topic, msg, fn){
     }
   } else {
     // wait for ready and retry
-    var self = this;
-
-    this.once('ready', function(){
-      self.publish(topic, msg, fn)
-    });
+    this.publishQueue.push([topic, msg, fn]);
   }
 };
 
@@ -176,15 +173,25 @@ Writer.prototype.connectTo = function(addr){
   this.pendingConns.add(conn);
 
   conn.on('close', function(){
-    debug('%s - remove from pool', addr);
     self.conns.remove(conn);
     self.pendingConns.add(conn);
+    debug('%s - remove from pool (total: %s)', addr, self.conns.size());
   });
 
   conn.on('ready', function(){
-    debug('%s - add to pool', addr);
     self.pendingConns.remove(conn);
     self.conns.add(conn);
+    debug('%s - add to pool (total: %s)', addr, self.conns.size());
+    
+    if (self.publishQueue.length > 0) {
+      debug('draining messages from the publish queue (total: %s)', self.publishQueue.length);
+
+      for (const [topic, msg, fn] of self.publishQueue) {
+        self.publish(topic, msg, fn);
+      }
+    }
+
+    self.publishQueue = [];
   });
 
   // TODO: poll


### PR DESCRIPTION
When the writer loses all connections, while it waits for a reconnection, each message it receives to publish creates a new ready listener. This can cause node to warn about a possible listener leak if too many messages are received. 

To avoid that, we instead add the messages to an array that will be drained after the ready event is sent.