### PR TITLE
Ignore missing topic errors on the health check

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -96,13 +96,7 @@ class Reader extends EventEmitter {
 
     // If we have a list of nsqlookupd servers,
     // do a lookup for relevant nodes and connect to them.
-    this.lookup((errors, nodes) => {
-      this.lookupErrors = errors?.length ?? 0;
-
-      for (const node of nodes) {
-        this.connectTo(node);
-      }
-    });
+    this.lookup();
 
     // Setup polling for nodes from the nsqlookupd servers.
     this.poll();
@@ -115,27 +109,14 @@ class Reader extends EventEmitter {
    */
 
   poll() {
+    // Clear the timer if one already exists.
+    if (this.timer) {
+      clearInterval(this.timer);
+    }
+
     debug('polling every %dms', this.pollInterval);
 
-    this.timer = setInterval(() => {
-      this.lookup((errors, nodes = []) => {
-        if (errors) {
-          debug('errors %j', errors);
-
-          for (const error of errors) {
-            this.emit('error lookup', error);
-          }
-
-          this.lookupErrors = errors.length;
-        } else {
-          this.lookupErrors = 0;
-        }
-
-        for (const node of nodes) {
-          this.connectTo(node);
-        }
-      });
-    }, this.pollInterval);
+    this.timer = setInterval(() => this.lookup(), this.pollInterval);
   }
 
   /**
@@ -145,19 +126,30 @@ class Reader extends EventEmitter {
    * @api private
    */
 
-  lookup(fn) {
+  lookup() {
     const addrs = this.nsqlookupd.map(utils.normalize);
 
     debug('lookup %j', addrs);
 
-    lookup(addrs, { timeout: 30000, topic: this.topic }, (errors, nodes) => {
-      if (!Array.isArray(nodes)) {
-        return fn();
-      }
-
+    lookup(addrs, { timeout: 30000, topic: this.topic }, (errors, nodes = []) => {
       debug('found %d nodes with topic %j', nodes.length, this.topic);
 
-      fn(errors, nodes.map(utils.nodeToAddress));
+      if (errors) {
+        debug('errors %j', errors);
+
+        for (const error of errors) {
+          this.emit('error lookup', error);
+        }
+
+        // Ignore TOPIC_NOT_FOUND errors, as they don't really mean that the lookup failed.
+        this.lookupErrors = utils.omitTopicNotFoundErrors(errors).length;
+      } else {
+        this.lookupErrors = 0;
+      }
+
+      for (const node of nodes) {
+        this.connectTo(utils.nodeToAddress(node));
+      }
     });
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,3 +54,19 @@ module.exports.nodeToAddress = node => `${node.broadcast_address}:${node.tcp_por
  */
 
 module.exports.normalize = address => address.startsWith('http') ? address : `http://${address}`;
+
+/**
+ * Omits TOPIC_NOT_FOUND errors from the list of errors.
+ *
+ * @param {Array} errors
+ * @returns {Array}
+ * @api private
+ */
+
+module.exports.omitTopicNotFoundErrors = errors => {
+  return errors.filter(error => {
+    const message = error?.response?.body?.status_txt ?? error?.response?.body?.message;
+
+    return message !== 'TOPIC_NOT_FOUND';
+  });
+};

--- a/test/acceptance/health-check.js
+++ b/test/acceptance/health-check.js
@@ -106,12 +106,37 @@ describe('Acceptance: Health Check', () => {
         });
       });
 
-      it('should show that lookups are failing', done => {
+      it('should consider `TOPIC_NOT_FOUND` errors to be a successful lookup', done => {
         const reader = new Reader({
           topic: topic + '1',
           channel: 'reader',
           healthCheck: true,
           nsqlookupd: ['127.0.0.1:4161']
+        });
+
+        setTimeout(() => {
+          try {
+            const healthCheck = reader.getHealthStatus();
+
+            assert.equal(healthCheck.connections.active, 0);
+            assert.equal(healthCheck.lookups.active, 1);
+            assert.equal(healthCheck.lookups.expected, 1);
+
+            reader.end();
+
+            done();
+          } catch (error) {
+            done(error);
+          }
+        }, 50);
+      });
+
+      it('should show that lookups are failing', done => {
+        const reader = new Reader({
+          topic: topic,
+          channel: 'reader',
+          healthCheck: true,
+          nsqlookupd: ['127.0.0.1:4160']
         });
 
         setTimeout(() => {

--- a/test/acceptance/reader.js
+++ b/test/acceptance/reader.js
@@ -7,7 +7,6 @@
 const assert = require('node:assert');
 const Reader = require('../../lib/reader');
 const Writer = require('../../lib/writer');
-const sinon = require('sinon');
 const uid = require('uid');
 const utils = require('../utils');
 
@@ -344,18 +343,13 @@ describe('Acceptance: Reader', () => {
 
       it('should emit lookup errors', done => {
         const sub = new Reader({
-          topic,
+          topic: `${topic}1`,
           channel: 'reader',
-          nsqlookupd: ['127.0.0.1:4161'],
-          pollInterval: 10
+          nsqlookupd: ['127.0.0.1:4161']
         });
 
-        sinon.stub(sub, 'lookup').onSecondCall().callsFake(fn => {
-          fn([new Error('foo')]);
-        });
-
-        sub.on('error lookup', error => {
-          assert.equal(error.message, 'foo');
+        sub.once('error lookup', error => {
+          assert.equal(error.response.body.message, 'TOPIC_NOT_FOUND');
 
           done();
         });


### PR DESCRIPTION
When a reader is setup with a topic that does not yet exist, the lookup will fail with a TOPIC_NOT_FOUND status.

Since this is an error, the health check is becoming degraded because of it, but it really shouldn't, the call to the nsqlookup worked, it is just that the error is misleading.

With this PR, this specific error will be ignored for health check purposes, although it will still be emitted through the `error lookup` event.